### PR TITLE
Add logs when job fails and always return git sha

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ async function runJob(account_id, job_id, cause, git_sha) {
 
 async function getJobRun(account_id, run_id) {
   try {
-    let res = await dbt_cloud_api.get(`/accounts/${account_id}/runs/${run_id}/`);
+    let res = await dbt_cloud_api.get(`/accounts/${account_id}/runs/${run_id}/?include_related=["run_steps"]`);
     return res.data;
   } catch (e) {
     let errorMsg = e.toString()
@@ -84,39 +84,50 @@ async function executeAction() {
   const cause = core.getInput('cause');
   const git_sha = core.getInput('git_sha') || null;
 
-  let res = await runJob(account_id, job_id, cause, git_sha);
-  let run_id = res.data.id;
+  const jobRun = await runJob(account_id, job_id, cause, git_sha);
+  const runId = jobRun.data.id;
 
-  core.info(`Triggered job. ${res.data.href}`);
+  core.info(`Triggered job. ${jobRun.data.href}`);
 
+  let res;
   while (true) {
     await sleep(core.getInput('interval') * 1000);
-    let res = await getJobRun(account_id, run_id);
+    res = await getJobRun(account_id, runId);
+
     if (!res) {
-      // Restart loop if there is no response
+      // Retry if there is no response
       continue;
     }
 
-    let run = res.data;
+    let status = run_status[res.data.status];
+    core.info(`Run: ${res.data.id} - ${status}`);
 
-    core.info(`Run: ${run.id} - ${run_status[run.status]}`);
-
-    if (run.finished_at) {
-      core.info('job finished');
-
-      let status = run_status[run.status];
-
-      if (status != 'Success') {
-        core.setFailed(`job finished with '${status}'.`);
-        return;
-      }
-
-      core.info(`job finished with '${status}'.`);
-      await getArtifacts(account_id, run_id);
-
-      return run['git_sha'];
+    if (res.data.is_complete) {
+      core.info(`job finished with '${status}'`);
+      break;
     }
   }
+
+  if (res.data.is_error) {
+    core.setFailed();
+  }
+
+  if (res.data.is_error) {
+    // Wait for the step information to load in run
+    core.info("Loading logs...")
+    await sleep(5000);
+    res = await getJobRun(account_id, runId);
+    // Print logs
+    for (let step of res.data.run_steps) {
+      core.info("# " + step.name)
+      core.info(step.logs)
+      core.info("\n************\n")
+    }
+  }
+
+  await getArtifacts(account_id, runId);
+
+  return jobRun.data['git_sha'];
 }
 
 async function main() {

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ async function executeAction() {
 
   await getArtifacts(account_id, runId);
 
-  return jobRun.data['git_sha'];
+  return res.data['git_sha'];
 }
 
 async function main() {


### PR DESCRIPTION
Example: https://github.com/fal-ai/fal_bike_example/runs/7867765138?check_suite_focus=true#step:3:18

```
Run: 75494151 - Error
job finished with 'Error'
Loading logs...
# Clone Git Repository
Cloning into '/tmp/jobs/75494151/target'...
Successfully cloned repository.
Checking out to 27c12436a60b4f9ed8236ead23db306f9a59d4e6...
Note: switching to '27c12436a60b4f9ed8236ead23db306f9a59d4e6'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 27c1243 introduce error


************

# Create Profile from Connection Bigquery 
Create Profile from Connection Bigquery 

************

# Invoke dbt with `dbt deps`
21:52:14  [WARNING]: Deprecated functionality
The `source-paths` config has been renamed to `model-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
21:52:14  [WARNING]: Deprecated functionality
The `data-paths` config has been renamed to `seed-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
21:52:14  Running with dbt=1.0.8
21:52:14  Warning: No packages were found in packages.yml


************

# Invoke dbt with `dbt run`
21:52:15  [WARNING]: Deprecated functionality
The `source-paths` config has been renamed to `model-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
21:52:15  [WARNING]: Deprecated functionality
The `data-paths` config has been renamed to `seed-paths`. Please update your
`dbt_project.yml` configuration to reflect this change.
21:52:15  Running with dbt=1.0.8
21:52:15  Partial parse save file not found. Starting full parse.
21:52:15  Found 2 models, 0 tests, 0 snapshots, 0 analyses, 188 macros, 0 operations, 0 seed files, 0 sources, 0 exposures, 0 metrics
21:52:15  
21:52:16  Concurrency: 4 threads (target='default')
21:52:16  
21:52:16  1 of 2 START table model dbt_test_action.bike_duration.......................... [RUN]
21:52:16  2 of 2 START table model dbt_test_action.bike_is_winner......................... [RUN]
21:52:16  2 of 2 ERROR creating table model dbt_test_action.bike_is_winner................ [ERROR in 0.65s]
21:52:18  1 of 2 OK created table model dbt_test_action.bike_duration..................... [CREATE TABLE (1.2k rows, 1.2 GB processed) in 2.76s]
21:52:18  
21:52:18  Finished running 2 table models in 3.19s.
21:52:18  
21:52:18  Completed with 1 error and 0 warnings:
21:52:18  
21:52:18  Database Error in model bike_is_winner (models/bike_is_winner.sql)
21:52:18    Syntax error: Expected ")" but got keyword AS at [12:63]
21:52:18    compiled SQL at target/run/fal_bike_example/models/bike_is_winner.sql
21:52:18  
21:52:18  Done. PASS=1 WARN=0 ERROR=1 SKIP=0 TOTAL=2


************

Saving artifacts in target directory
dbt Cloud Job commit SHA is 27c12436a60b4f9ed8236ead23db306f9a59d4e6
```

*****

And: https://github.com/fal-ai/fal_bike_example/runs/7867803364?check_suite_focus=true#step:3:17

```
Triggered job. https://cloud.getdbt.com/#/accounts/***/projects/68181/runs/75494399/
Run: 75494399 - Queued
Run: 75494399 - Starting
Run: 75494399 - Running
Run: 75494399 - Running
Run: 75494399 - Success
job finished with 'Success'
Saving artifacts in target directory
dbt Cloud Job commit SHA is 65aff7f7ba713c23bfb9fbf169fd1b27773c1fbc
```