### PR TITLE
Let action work with dbt cloud jobs which don't produce artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ We recommend passing sensitive variables as GitHub secrets. [Example usage](http
 
 - `failure_on_error` - Boolean to make the action report a failure when dbt-cloud runs. Mark this as `false` to run fal after the dbt-cloud job.
 - `interval` - The interval between polls in seconds (Default: `30`)
+- `get_artifacts` - Whether run results, needed by fal, are fetched from dbt cloud. If using this action in other contexts this can be set to `false`, useful for jobs which do not generate artifacts.
 
 ### dbt Cloud Job configuration
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   failure_on_error:
     description: Boolean to make the action report a failure when dbt-cloud runs. Mark this as `false` to run fal after the dbt-cloud job.
     required: true
+  get_artifacts:
+    description: Whether run results, needed by fal, are fetched from dbt cloud. If using this action in other contexts this can be set to `false`, useful for jobs which do not generate artifacts.
+    required: false
+    default: true
 
   cause:
     description: Job trigger cause

--- a/index.js
+++ b/index.js
@@ -166,7 +166,9 @@ async function executeAction() {
     }
   }
 
-  await getArtifacts(account_id, runId);
+  if (core.getBooleanInput('get_artifacts')) {
+    await getArtifacts(account_id, runId);
+  }
 
   const outputs = {
     "git_sha": res.data['git_sha'],


### PR DESCRIPTION
Fixes #23

Previously this action would always fail on dbt cloud jobs which don't produce artifacts, now the action can be configured to skip fetching artifacts. I considered catching & silencing errors when fetching artifacts rather than exposing another config option but decided against it since it could lead to hard-to-debug scenarios for this github action's primary use-case (running fal). Requiring a configuration opt-in to cover this niche instead feels quite harmless.

# Questions

* Do you have any tips for testing this? I've never worked on a Github Action before
* Does the approach generally look ok to you?

I'm very open to any style or naming suggestions, and any other advice you have to give. Thanks
