### PR TITLE
Add option to not wait for dbt job to finish

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,12 @@ inputs:
     required: false
     # type: array of strings
 
+  wait_for_job:
+    description: 
+    required: false
+    default: true
+
+
 outputs:
   git_sha:
     description: "Repository SHA in which dbt Cloud Job ran"

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ inputs:
     # type: array of strings
 
   wait_for_job:
-    description: 
+    description: Boolean for whether action should wait until dbt job finishes
     required: false
     default: true
 

--- a/index.js
+++ b/index.js
@@ -143,8 +143,13 @@ async function executeAction() {
     let status = run_status[res.data.status];
     core.info(`Run: ${res.data.id} - ${status}`);
 
-    if (res.data.is_complete) {
-      core.info(`job finished with '${status}'`);
+    if (core.getBooleanInput('wait_for_job')) {
+      if (res.data.is_complete) {
+        core.info(`job finished with '${status}'`);
+        break;
+      }
+    } else {
+      core.info("Not waiting for job to finish. Relevant run logs will be omitted.")
       break;
     }
   }


### PR DESCRIPTION
This PR adds an optional input to determine whether the action should wait for its triggered job to finish. It's set to `true` by default for backward compatibility.