### PR TITLE
Add dbt cloud API parameterization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Example usage at [fal-ai/fal_bike_example](https://github.com/fal-ai/fal_bike_ex
 
 ### Credentials
 
-- `dbt_cloud_url` - dbt Cloud [API URL](https://docs.getdbt.com/dbt-cloud/api-v2#/) (Default: `cloud.getdbt.com`)
+- `dbt_cloud_url` - dbt Cloud [API URL](https://docs.getdbt.com/dbt-cloud/api-v2#/) (Default: `https://cloud.getdbt.com`)
 - `dbt_cloud_token` - dbt Cloud [API token](https://docs.getdbt.com/docs/dbt-cloud/dbt-cloud-api/service-tokens)
 - `dbt_cloud_account_id` - dbt Cloud Account ID
 - `dbt_cloud_job_id` - dbt Cloud Job ID

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Example usage at [fal-ai/fal_bike_example](https://github.com/fal-ai/fal_bike_ex
 
 ### Credentials
 
+- `dbt_cloud_url` - dbt Cloud [API URL](https://docs.getdbt.com/dbt-cloud/api-v2#/) (Default: `cloud.getdbt.com`)
 - `dbt_cloud_token` - dbt Cloud [API token](https://docs.getdbt.com/docs/dbt-cloud/dbt-cloud-api/service-tokens)
 - `dbt_cloud_account_id` - dbt Cloud Account ID
 - `dbt_cloud_job_id` - dbt Cloud Job ID

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ branding:
   icon: "cloud"
   color: "orange"
 inputs:
+  dbt_cloud_url:
+    description: dbt Cloud base API URL
+    required: false
+    default: cloud.getdbt.com
   dbt_cloud_token:
     description: dbt Cloud API token
     required: true

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   dbt_cloud_url:
     description: dbt Cloud base API URL
     required: false
-    default: cloud.getdbt.com
+    default: https://cloud.getdbt.com
   dbt_cloud_token:
     description: dbt Cloud API token
     required: true

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const run_status = {
 }
 
 const dbt_cloud_api = axios.create({
-  baseURL: 'https://cloud.getdbt.com/api/v2/',
+  baseURL: `https://${core.getInput('dbt_cloud_url')}/api/v2/`,
   timeout: 5000, // 5 seconds
   headers: {
     'Authorization': `Token ${core.getInput('dbt_cloud_token')}`,

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const run_status = {
 }
 
 const dbt_cloud_api = axios.create({
-  baseURL: `https://${core.getInput('dbt_cloud_url')}/api/v2/`,
+  baseURL: `${core.getInput('dbt_cloud_url')}/api/v2/`,
   timeout: 5000, // 5 seconds
   headers: {
     'Authorization': `Token ${core.getInput('dbt_cloud_token')}`,


### PR DESCRIPTION
The API URL is currently hardcoded to https://cloud.getdbt.com which is the one for "Production (US)".

This Pull request introduces a new optional paramater `dbt_cloud_url` so that other endpoints can be used as documented in https://docs.getdbt.com/dbt-cloud/api-v2#/; e.g.: 

- Production (Europe): https://emea.dbt.com
- Production (AU): https://au.dbt.com