### PR TITLE
bump node version from 16 to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,5 +85,5 @@ outputs:
   run_id:
     description: "Run ID of the dbt Cloud Job that was triggered"
 runs:
-  using: node16
+  using: node20
   main: "index.js"


### PR DESCRIPTION
Node16 is at [end of life](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), so running this action gives a warning annotation:

>    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: fal-ai/dbt-cloud-action@main. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.