### PR TITLE
Handle cancelling dbt Cloud jobs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,3 +87,4 @@ outputs:
 runs:
   using: node20
   main: "index.js"
+  post: "index.js"

--- a/index.js
+++ b/index.js
@@ -197,10 +197,12 @@ async function cleanupAction() {
   let res = await getJobRun(account_id, run_id);
   let isComplete = run_status[res.data.is_complete];
 
-  // if it is running and we want to wait for the end of the job, cancel it
+  // if it is running and we wanted to wait for the end of the job, cancel it
   if ((! isComplete) && core.getBooleanInput('wait_for_job')) {
     core.info('Cancelling job...')
     await dbt_cloud_api.post(`/accounts/${account_id}/runs/${run_id}/cancel/`);
+  } else {
+    core.info('Nothing to clean')
   }
 
 }

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ async function runJob(account_id, job_id) {
       }
     }
 
-    // Type-checking equality becuase of boolean inputs
+    // Type-checking equality because of boolean inputs
     if (input !== '') {
       body[key] = input;
     }
@@ -129,6 +129,10 @@ async function executeAction() {
   const runId = jobRun.data.id;
 
   core.info(`Triggered job. ${jobRun.data.href}`);
+  // we save this info to clean up the job later if it is cancelled
+  fs.appendFileSync(process.env.GITHUB_STATE, `dbtCloudRunID=${jobRun.data.id}${os.EOL}`, {
+    encoding: 'utf8'
+  })
 
   let res;
   while (true) {
@@ -183,20 +187,48 @@ async function executeAction() {
   return outputs;
 }
 
-async function main() {
-  try {
-    const outputs = await executeAction();
-    const git_sha = outputs["git_sha"];
-    const run_id = outputs["run_id"];
 
-    // GitHub Action output
-    core.info(`dbt Cloud Job commit SHA is ${git_sha}`)
-    core.setOutput('git_sha', git_sha);
-    core.setOutput('run_id', run_id);
-  } catch (e) {
-    // Always fail in this case because it is not a dbt error
-    core.setFailed('There has been a problem with running your dbt cloud job:\n' + e.toString());
-    core.debug(e.stack)
+async function cleanupAction() {
+  const account_id = core.getInput('dbt_cloud_account_id');
+  const run_id = process.env.STATE_dbtCloudRunID;
+
+  // get the job status
+  let res = await getJobRun(account_id, run_id);
+  let isComplete = run_status[res.data.is_complete];
+
+  // if it is running and we want to wait for the end of the job, cancel it
+  if ((! isComplete) && core.getBooleanInput('wait_for_job')) {
+    core.info('Cancelling job...')
+    await dbt_cloud_api.post(`/accounts/${account_id}/runs/${run_id}/cancel/`);
+  }
+
+}
+
+async function main() {
+  if (process.env.STATE_dbtCloudRunID === undefined) {
+    // we haven't created th job yet
+    try {
+      const outputs = await executeAction();
+      const git_sha = outputs["git_sha"];
+      const run_id = outputs["run_id"];
+  
+      // GitHub Action output
+      core.info(`dbt Cloud Job commit SHA is ${git_sha}`)
+      core.setOutput('git_sha', git_sha);
+      core.setOutput('run_id', run_id);
+    } catch (e) {
+      // Always fail in this case because it is not a dbt error
+      core.setFailed('There has been a problem with running your dbt cloud job:\n' + e.toString());
+      core.debug(e.stack)
+    }
+  } else {
+    // we have created the job
+    try {
+      await cleanupAction();
+    } catch (e) {
+      core.error('There has been a problem with cleaning up your dbt cloud job:\n' + e.toString());
+      core.debug(e.stack)
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const core = require('@actions/core');
 const fs = require('fs');
+const os = require('os');
 const axiosRetry = require('axios-retry');
 const YAML = require('yaml')
 

--- a/index.js
+++ b/index.js
@@ -195,10 +195,9 @@ async function cleanupAction() {
 
   // get the job status
   let res = await getJobRun(account_id, run_id);
-  let isComplete = run_status[res.data.is_complete];
 
   // if it is running and we wanted to wait for the end of the job, cancel it
-  if ((! isComplete) && core.getBooleanInput('wait_for_job')) {
+  if ((! res.data.is_complete) && core.getBooleanInput('wait_for_job')) {
     core.info('Cancelling job...')
     await dbt_cloud_api.post(`/accounts/${account_id}/runs/${run_id}/cancel/`);
   } else {


### PR DESCRIPTION
Solves #20 

Adding logic to cancel the job that was triggered if the action is still running when we cancel it.

It can be useful when `workflow_dispatch` is used, but also especially when people trigger CI jobs using this action.

With the additional config
```
on:
  - pull_request

concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
...
```

we can actually trigger dbt Cloud CI jobs from the action and if we push more commits to the PR, it will trigger a new CI job and cancel the previous one.